### PR TITLE
Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,10 +990,10 @@ class MyClass:
         return cls.class_attribute + x + y
 
 result1 = MyClass.my_class_method(3, 4)
-print(result1)  # Output: 2 + 3 + 4 = 9
+print(result1)  # Output: 1 + 3 + 4 = 8
 
 result2 = MyClass.my_class_method(1, 2)
-print(result2)  # Output: 3 + 1 + 2 = 6
+print(result2)  # Output: 2 + 1 + 2 = 5
 ```
 
 3. **Static Methods:**

--- a/README.md
+++ b/README.md
@@ -457,7 +457,8 @@ are a few examples of how you can use **lambda functions in Django**:
   You can use a lambda function as a condition for filtering objects in a Django queryset. For instance:
 
 ```
-filtered_queryset = MyModel.objects.filter(lambda obj: obj.field_name == 'some_value')
+filtered_queryset = MyModel.objects.all() 
+filtered_objects = filter(lambda obj: obj.field_name == 'some_value', objects)
 ```
 
 ### Exception Handling

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Inheritance is a mechanism that allows a class to inherit properties and methods
 inherits from another class is called a subclass or derived class, while the class that is being inherited from is
 called a superclass or base class.
 
+
+
 ```
 class Animal:
     def __init__(self, name):


### PR DESCRIPTION
You can't use lambda functions directly in a Django queryset filter. Django's ORM (Object-Relational Mapping) system uses a different syntax to filter querysets, and this syntax doesn't support lambda functions directly.f you need to perform more complex queries, Django supports a number of lookup types which can be used to implement more complex logic.However, if you absolutely need to apply a function to each object in the queryset, you can't do it directly in the filter clause. You'll need to fetch the objects into memory and then use Python's built-in filter() function.

objects = MyModel.objects.all()  # Be careful with this if you have a lot of objects
filtered_objects = filter(lambda obj: obj.field_name == 'some_value', objects)

This is generally less efficient than doing the filtering in the database, so you should only do this if you can't express your filter condition using Django's ORM syntax.